### PR TITLE
Add URL filters

### DIFF
--- a/adage/adage/urls.py
+++ b/adage/adage/urls.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
 from analyze.views import (
+    EdgeViewSet,
     ExperimentViewSet,
     MLModelViewSet,
     SampleViewSet,
@@ -13,12 +14,13 @@ from genes.views import GeneViewSet
 from organisms.views import OrganismViewSet
 
 router = routers.DefaultRouter()
-router.register(r"experiments", ExperimentViewSet, basename="experiment")
-router.register(r"genes", GeneViewSet, basename="gene")
-router.register(r"models", MLModelViewSet)
-router.register(r"organisms", OrganismViewSet)
-router.register(r"samples", SampleViewSet)
-router.register(r"signatures", SignatureViewSet)
+router.register(r"edge", EdgeViewSet)
+router.register(r"experiment", ExperimentViewSet, basename="experiment")
+router.register(r"gene", GeneViewSet, basename="gene")
+router.register(r"model", MLModelViewSet)
+router.register(r"organism", OrganismViewSet)
+router.register(r"sample", SampleViewSet)
+router.register(r"signature", SignatureViewSet)
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/adage/analyze/serializers.py
+++ b/adage/analyze/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
-from .models import Experiment, MLModel, Sample, SampleAnnotation, Signature
+from .models import (
+    Experiment, MLModel, Sample, SampleAnnotation, Signature, Edge
+)
 
 
 class ExperimentSerializer(serializers.ModelSerializer):
@@ -67,3 +69,9 @@ class SignatureSerializer(serializers.ModelSerializer):
     class Meta:
         model = Signature
         exclude = ['samples']
+
+
+class EdgeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Edge
+        fields = '__all__'

--- a/adage/analyze/views.py
+++ b/adage/analyze/views.py
@@ -1,18 +1,20 @@
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from rest_framework.viewsets import ReadOnlyModelViewSet
-from .models import Experiment, MLModel, Sample, Signature
+from .models import Experiment, MLModel, Sample, Signature, Edge
 from .serializers import (
     ExperimentSerializer,
     MLModelSerializer,
     SampleSerializer,
     SignatureSerializer,
+    EdgeSerializer,
 )
 
 class ExperimentViewSet(ReadOnlyModelViewSet):
-    """Experiments viewset."""
+    """Experiment viewset. Supported parameters: `accession`, `search`"""
 
     http_method_names = ['get']
     serializer_class = ExperimentSerializer
+    filterset_fields = ['accession', ]
 
     def get_queryset(self):
         queryset = Experiment.objects.all()
@@ -41,7 +43,7 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
 
 
 class MLModelViewSet(ReadOnlyModelViewSet):
-    """Machine learning models viewset."""
+    """Machine learning model viewset."""
 
     http_method_names = ['get']
     queryset = MLModel.objects.all()
@@ -49,7 +51,7 @@ class MLModelViewSet(ReadOnlyModelViewSet):
 
 
 class SampleViewSet(ReadOnlyModelViewSet):
-    """Samples viewset."""
+    """Sample viewset."""
 
     http_method_names = ['get']
     queryset = Sample.objects.all()
@@ -57,8 +59,18 @@ class SampleViewSet(ReadOnlyModelViewSet):
 
 
 class SignatureViewSet(ReadOnlyModelViewSet):
-    """Signatures viewset."""
+    """Signature viewset. Supported parameter: `mlmodel`"""
 
     http_method_names = ['get']
     queryset = Signature.objects.all()
     serializer_class = SignatureSerializer
+    filterset_fields = ['mlmodel', ]
+
+
+class EdgeViewSet(ReadOnlyModelViewSet):
+    """Gene-gene edge viewset. Supported parameter: `mlmodel`"""
+
+    http_method_names = ['get']
+    queryset = Edge.objects.all()
+    serializer_class = EdgeSerializer
+    filterset_fields = ['mlmodel', ]

--- a/adage/genes/tests.py
+++ b/adage/genes/tests.py
@@ -33,7 +33,7 @@ class GeneSearchAPITests(APITestCase):
                 standard_name=(self.std_prefix + letter), organism=self.organism
             )
 
-        self.api_base = '/api/v1/genes/'
+        self.api_base = '/api/v1/gene/'
         self.client = APIClient()
 
     def test_get_search(self):

--- a/adage/genes/views.py
+++ b/adage/genes/views.py
@@ -9,7 +9,7 @@ from .serializers import GeneSerializer
 
 
 class GeneViewSet(ModelViewSet):
-    """Genes viewset."""
+    """Genes viewset. Supported parameters: `search`, `autocomplete`"""
 
     http_method_names = ['get', 'post']
     serializer_class = GeneSerializer


### PR DESCRIPTION
This PR adds filters to a few viewset classes. The URLs are also tweaked so that they will be consistent to the original APIs that is being used on Adage and Tribe web servers.