### PR TITLE
Manually handle mlmodel parameter first

### DIFF
--- a/adage/analyze/views.py
+++ b/adage/analyze/views.py
@@ -82,10 +82,22 @@ class EdgeViewSet(ReadOnlyModelViewSet):
 
     http_method_names = ['get']
     serializer_class = EdgeSerializer
-    filterset_fields = ['mlmodel', ]
 
     def get_queryset(self):
         queryset = Edge.objects.all()
+
+        # If "mlmodel" parameter is found, always handle it first.
+        mlmodel = self.request.query_params.get('mlmodel', None)
+        if mlmodel:
+            try:
+                mlmodel_id = int(mlmodel)
+            except ValueError:
+                raise ParseError(
+                    {'error': f'mlmodel not an integer: {mlmodel}'}
+                )
+            queryset = queryset.filter(mlmodel=mlmodel_id)
+
+        # Handle "genes" parameter
         genes = self.request.query_params.get('genes', None)
         if genes:
             try:


### PR DESCRIPTION
By default, the filters in `filterset_fields` in a DRF view is applied after `get_queryset` methods. This makes the `genes` filter apply to edges in all mlmodels, and the result is wrong.

To fix it, `mlmodel` parameter in the URL is handled manually before any other parameters.