### PR TITLE
"Experiment" autocomplete search: Use substr on `name` and `description` fields

### DIFF
--- a/adage/analyze/views.py
+++ b/adage/analyze/views.py
@@ -68,7 +68,7 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
                     'accession', similarity_str
                 )
             ).filter(
-                Q(accession_match__gt=0.3) |
+                Q(accession_match__gt=0.1) |
                 Q(name__icontains=similarity_str) |
                 Q(description__icontains=similarity_str)
             ).annotate(

--- a/adage/analyze/views.py
+++ b/adage/analyze/views.py
@@ -58,9 +58,9 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
         # the following fields:
         # - "name"
         # - "description"
-        # The reason why trigram search on these three fields are not used is
-        # because the strings in these three fields are long, so most matches
-        # have much less similarity values in trigram search.
+        # The reason why trigram search is not used on these fields is because
+        # when values of these fields are long strings, trigram similarity
+        # score becomes tiny.
         similarity_str = self.request.query_params.get('autocomplete', None)
         if similarity_str is not None:
             queryset = queryset.annotate(

--- a/adage/analyze/views.py
+++ b/adage/analyze/views.py
@@ -54,7 +54,7 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
             ).order_by('-rank', 'accession')
 
         # Extract the 'autocomplete' parameter from the incoming query and
-        # perform trigram search on "accession" field, and substring search on
+        # perform trigram search on "accession" field and substring search on
         # the following fields:
         # - "name"
         # - "description"

--- a/adage/analyze/views.py
+++ b/adage/analyze/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Case, CharField, F, Q, Value, When
+from django.db.models import Case, CharField, F, IntegerField, Q, Value, When
 from django.db.models.functions import Greatest
 from django.contrib.postgres.search import (
     SearchQuery, SearchRank, SearchVector, TrigramSimilarity
@@ -54,46 +54,44 @@ class ExperimentViewSet(ReadOnlyModelViewSet):
             ).order_by('-rank', 'accession')
 
         # Extract the 'autocomplete' parameter from the incoming query and
-        # perform trigram search on the following fields in Experiment model:
-        # - "accession"
+        # perform trigram search on "accession" field, and substring search on
+        # the following fields:
         # - "name"
         # - "description"
-        # - "samples_info"
+        # The reason why trigram search on these three fields are not used is
+        # because the strings in these three fields are long, so most matches
+        # have much less similarity values in trigram search.
         similarity_str = self.request.query_params.get('autocomplete', None)
         if similarity_str is not None:
             queryset = queryset.annotate(
-                accession_similarity=TrigramSimilarity('accession', similarity_str),
-                name_similarity=TrigramSimilarity('name', similarity_str),
-                desc_similarity=TrigramSimilarity('description', similarity_str),
-                samples_similarity=TrigramSimilarity('samples_info', similarity_str),
-            ).annotate(
-                similarity=(
-                    F('accession_similarity') + F('name_similarity') +
-                    F('desc_similarity') + F('samples_similarity')
-                ),
-                max_similarity=Greatest(
-                    'accession_similarity', 'name_similarity',
-                    'desc_similarity', 'samples_similarity'
+                accession_match=TrigramSimilarity(
+                    'accession', similarity_str
                 )
+            ).filter(
+                Q(accession_match__gt=0.3) |
+                Q(name__icontains=similarity_str) |
+                Q(description__icontains=similarity_str)
+            ).annotate(
+                name_match=Case(
+                    When(name__icontains=similarity_str, then=Value(1)),
+                    default=Value(0),
+                    output_field=IntegerField(),
+                ),
+                desc_match=Case(
+                    When(description__icontains=similarity_str, then=Value(1)),
+                    default=Value(0),
+                    output_field=IntegerField(),
+                ),
             ).annotate(
                 max_similarity_field=Case(
-                    When(accession_similarity__gte=F('max_similarity'),
-                         then=Value("accession")
-                    ),
-                    When(name_similarity__gte=F('max_similarity'),
-                         then=Value("name")
-                    ),
-                    When(desc_similarity__gte=F('max_similarity'),
-                         then=Value("description")
-                    ),
-                    When(samples_similarity__gte=F('max_similarity'),
-                         then=Value("samples")
-                    ),
-                    output_field=CharField(),
+                    When(accession_match__gte=0.1, then=Value("accession")),
+                    When(name_match=1, then=Value("name")),
+                    When(desc_match=1, then=Value("description")),
+                    output_field=CharField()
                 )
-            ).filter(similarity__gte=0.1
-            ).order_by('-max_similarity', '-similarity', 'accession')
-
+            ).order_by(
+                '-accession_match', '-name_match', '-desc_match'
+            )
 
         return queryset
 

--- a/adage/requirements.txt
+++ b/adage/requirements.txt
@@ -3,5 +3,6 @@ django-cors-headers==3.2.1
 django-filter==2.2.0
 djangorestframework==3.11.0
 gunicorn==19.9.0
+Markdown==3.2.1
 psycopg2==2.8.4
 PyYAML==5.3


### PR DESCRIPTION
This PR uses substr search on `name` and `description` fields in the `Experiment` autocomplete search API, because trigram searches on `name` and `description` fields don't work very well when `name` and/or `description` fields in an experiment is a long string. (The trigram similarity score  depends not only on the number of matched trigrams but also on the original string's length.)
